### PR TITLE
Add PostGIS 2.3.1 scripts package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ ENV POSTGIS_VERSION 2.3.1+dfsg-1.pgdg80+1
 
 RUN apt-get update \
       && apt-get install -y --no-install-recommends \
-           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
-           postgis=$POSTGIS_VERSION \
+           postgresql-$PG_MAJOR-postgis-${POSTGIS_MAJOR}=${POSTGIS_VERSION} \
+           postgresql-$PG_MAJOR-postgis-${POSTGIS_MAJOR}-scripts=${POSTGIS_VERSION} \
+           postgis=${POSTGIS_VERSION} \
       && rm -rf /var/lib/apt/lists/*
 
 


### PR DESCRIPTION
It must be a packaging issue but the core 2.3.1 dfsg package does not include the postgis.control file that is needed by liquibase.  Adding the scripts package solves the issue and allows the database update to complete.