### PR TITLE
add index for performance

### DIFF
--- a/liquibase/changeLogs/nldi/nldi_data/changeLog.xml
+++ b/liquibase/changeLogs/nldi/nldi_data/changeLog.xml
@@ -11,6 +11,7 @@
 	</preConditions>
 
 	<include file="tables.sql" relativeToChangelogFile="true"/>
+	<include file="indexes.sql" relativeToChangelogFile="true"/>
 	<include file="functions/changeLog.xml" relativeToChangelogFile="true"/>
 	<include file="grants.sql" relativeToChangelogFile="true"/>
 	<include file="update_crawler_source/changeLog.yml" relativeToChangelogFile="true"/>

--- a/liquibase/changeLogs/nldi/nldi_data/changeLog.xml
+++ b/liquibase/changeLogs/nldi/nldi_data/changeLog.xml
@@ -11,7 +11,7 @@
 	</preConditions>
 
 	<include file="tables.sql" relativeToChangelogFile="true"/>
-	<include file="indexes.sql" relativeToChangelogFile="true"/>
+	<include file="indexes/changeLog.yml" relativeToChangelogFile="true"/>
 	<include file="functions/changeLog.xml" relativeToChangelogFile="true"/>
 	<include file="grants.sql" relativeToChangelogFile="true"/>
 	<include file="update_crawler_source/changeLog.yml" relativeToChangelogFile="true"/>

--- a/liquibase/changeLogs/nldi/nldi_data/indexes.sql
+++ b/liquibase/changeLogs/nldi/nldi_data/indexes.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+
+--changeset kkehl:create_index.nldi_data.web_service_log_id_idx runAlways:true
+--preconditions onFail:MARK_RAN onError:HALT
+--precondition-sql-check expectedResult:0 select count(*) from pg_class c join pg_namespace n on n.oid = c.relnamespace where n.nspname = 'nldi_data' and c.relname = 'web_service_log_id_idx' and c.relkind = 'i'
+create index web_service_log_id_idx on nldi_data.web_service_log(web_service_log_id);
+--rollback drop index nldi_data.web_service_log_id_idx;
+

--- a/liquibase/changeLogs/nldi/nldi_data/indexes.sql
+++ b/liquibase/changeLogs/nldi/nldi_data/indexes.sql
@@ -1,8 +1,0 @@
---liquibase formatted sql
-
---changeset kkehl:create_index.nldi_data.web_service_log_id_idx runAlways:true
---preconditions onFail:MARK_RAN onError:HALT
---precondition-sql-check expectedResult:0 select count(*) from pg_class c join pg_namespace n on n.oid = c.relnamespace where n.nspname = 'nldi_data' and c.relname = 'web_service_log_id_idx' and c.relkind = 'i'
-create index web_service_log_id_idx on nldi_data.web_service_log(web_service_log_id);
---rollback drop index nldi_data.web_service_log_id_idx;
-

--- a/liquibase/changeLogs/nldi/nldi_data/indexes/changeLog.yml
+++ b/liquibase/changeLogs/nldi/nldi_data/indexes/changeLog.yml
@@ -1,0 +1,10 @@
+databaseChangeLog:
+  - preConditions:
+      - dbms:
+          type: postgresql
+    -runningAs:
+      username: ${NLDI_SCHEMA_OWNER_USERNAME}
+
+  - include:
+      - file: webServiceLogId.yml
+      - relativeToChangelogFile: true

--- a/liquibase/changeLogs/nldi/nldi_data/indexes/webServiceLogId.yml
+++ b/liquibase/changeLogs/nldi/nldi_data/indexes/webServiceLogId.yml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+- changeSet:
+    author: kkehl
+    id: "create.index.nldi_data.web_service_log_id_identifier"
+    preConditions:
+      - onFail: MARK_RAN
+      - onError: HALT
+      - not:
+          - indexExists:
+              NLDI_SCHEMA_NAME: nldi_data
+              indexName: web_service_log_id_identifier
+    changes:
+      - sql: create index web_service_log_id_identifier on nldi_data.web_service_log(web_service_log_id);
+      - rollback: drop index if exists nldi_data.web_service_log_id_identifier;


### PR DESCRIPTION
On prod, the query for nldi_data.log_request_end is getting bogged down and causing nldi to hit max db connections.   Looking at explain for the query, it's doing a sequential scan to find the web_service_log_id.    So add an index for web_service_log_id so postgres can do an index scan instead.