### PR TITLE
Updated build artifact endpoints

### DIFF
--- a/database/ci/Dockerfile
+++ b/database/ci/Dockerfile
@@ -11,5 +11,5 @@ COPY ./liquibase/scripts/*.sh /docker-entrypoint-initdb.d/
 COPY ./liquibase/scripts/dbInit /docker-entrypoint-initdb.d/
 COPY ./liquibase/scripts/dbCi /docker-entrypoint-initdb.d/
 
-RUN curl --verbose  "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/nhdplus.yahara.pgdump.gz" -o $LIQUIBASE_HOME/nhdplus.yahara.pgdump.gz
-RUN curl --verbose  "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/characteristic_data.yahara.pgdump.gz" -o $LIQUIBASE_HOME/characteristic_data.yahara.pgdump.gz
+RUN curl -L --verbose  "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/nhdplus.yahara.pgdump.gz" -o $LIQUIBASE_HOME/nhdplus.yahara.pgdump.gz
+RUN curl -L --verbose  "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/characteristic_data.yahara.pgdump.gz" -o $LIQUIBASE_HOME/characteristic_data.yahara.pgdump.gz

--- a/database/ci/Dockerfile
+++ b/database/ci/Dockerfile
@@ -11,5 +11,5 @@ COPY ./liquibase/scripts/*.sh /docker-entrypoint-initdb.d/
 COPY ./liquibase/scripts/dbInit /docker-entrypoint-initdb.d/
 COPY ./liquibase/scripts/dbCi /docker-entrypoint-initdb.d/
 
-RUN curl --verbose  "https://artifactory.wma.usgs.gov/artifactory/wma-binaries/iow/nldi/nhdplus.yahara.pgdump.gz" -o $LIQUIBASE_HOME/nhdplus.yahara.pgdump.gz
-RUN curl --verbose  "https://artifactory.wma.usgs.gov/artifactory/wma-binaries/iow/nldi/characteristic_data.yahara.pgdump.gz" -o $LIQUIBASE_HOME/characteristic_data.yahara.pgdump.gz
+RUN curl --verbose  "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/nhdplus.yahara.pgdump.gz" -o $LIQUIBASE_HOME/nhdplus.yahara.pgdump.gz
+RUN curl --verbose  "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/characteristic_data.yahara.pgdump.gz" -o $LIQUIBASE_HOME/characteristic_data.yahara.pgdump.gz

--- a/database/demo/Dockerfile
+++ b/database/demo/Dockerfile
@@ -13,9 +13,9 @@ COPY ./liquibase/scripts/dbCi /docker-entrypoint-initdb.d/
 COPY ./liquibase/scripts/dbDemo /docker-entrypoint-initdb.d/
 
 
-RUN curl --verbose "https://artifactory.wma.usgs.gov/artifactory/wma-binaries/iow/nldi/nhdplus.yahara.pgdump.gz" -o $LIQUIBASE_HOME/nhdplus.yahara.pgdump.gz
-RUN curl --verbose "https://artifactory.wma.usgs.gov/artifactory/wma-binaries/iow/nldi/characteristic_data.yahara.pgdump.gz" -o $LIQUIBASE_HOME/characteristic_data.yahara.pgdump.gz
-RUN curl --verbose "https://artifactory.wma.usgs.gov/artifactory/wma-binaries/iow/nldi/nldi_data.crawler_source.pgdump.gz" -o $LIQUIBASE_HOME/nldi_data.crawler_source.pgdump.gz
-RUN curl --verbose "https://artifactory.wma.usgs.gov/artifactory/wma-binaries/iow/nldi/feature_wqp_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_wqp_yahara.backup.gz
-RUN curl --verbose "https://artifactory.wma.usgs.gov/artifactory/wma-binaries/iow/nldi/feature_huc12pp_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_huc12pp_yahara.backup.gz
-RUN curl --verbose "https://artifactory.wma.usgs.gov/artifactory/wma-binaries/iow/nldi/feature_np21_nwis_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_np21_nwis_yahara.backup.gz
+RUN curl --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/nhdplus.yahara.pgdump.gz" -o $LIQUIBASE_HOME/nhdplus.yahara.pgdump.gz
+RUN curl --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/characteristic_data.yahara.pgdump.gz" -o $LIQUIBASE_HOME/characteristic_data.yahara.pgdump.gz
+RUN curl --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/nldi_data.crawler_source.pgdump.gz" -o $LIQUIBASE_HOME/nldi_data.crawler_source.pgdump.gz
+RUN curl --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/feature_wqp_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_wqp_yahara.backup.gz
+RUN curl --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/feature_huc12pp_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_huc12pp_yahara.backup.gz
+RUN curl --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/feature_np21_nwis_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_np21_nwis_yahara.backup.gz

--- a/database/demo/Dockerfile
+++ b/database/demo/Dockerfile
@@ -13,9 +13,9 @@ COPY ./liquibase/scripts/dbCi /docker-entrypoint-initdb.d/
 COPY ./liquibase/scripts/dbDemo /docker-entrypoint-initdb.d/
 
 
-RUN curl --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/nhdplus.yahara.pgdump.gz" -o $LIQUIBASE_HOME/nhdplus.yahara.pgdump.gz
-RUN curl --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/characteristic_data.yahara.pgdump.gz" -o $LIQUIBASE_HOME/characteristic_data.yahara.pgdump.gz
-RUN curl --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/nldi_data.crawler_source.pgdump.gz" -o $LIQUIBASE_HOME/nldi_data.crawler_source.pgdump.gz
-RUN curl --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/feature_wqp_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_wqp_yahara.backup.gz
-RUN curl --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/feature_huc12pp_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_huc12pp_yahara.backup.gz
-RUN curl --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/feature_np21_nwis_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_np21_nwis_yahara.backup.gz
+RUN curl -L --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/nhdplus.yahara.pgdump.gz" -o $LIQUIBASE_HOME/nhdplus.yahara.pgdump.gz
+RUN curl -L --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/characteristic_data.yahara.pgdump.gz" -o $LIQUIBASE_HOME/characteristic_data.yahara.pgdump.gz
+RUN curl -L --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/nldi_data.crawler_source.pgdump.gz" -o $LIQUIBASE_HOME/nldi_data.crawler_source.pgdump.gz
+RUN curl -L --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/feature_wqp_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_wqp_yahara.backup.gz
+RUN curl -L --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/feature_huc12pp_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_huc12pp_yahara.backup.gz
+RUN curl -L --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/feature_np21_nwis_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_np21_nwis_yahara.backup.gz


### PR DESCRIPTION
The previous Artifactory endpoint was causing inconsistent build failures and will be discontinued in the near future. I have uploaded the necessary files as a release ([artifacts-1.0.0](https://github.com/ACWI-SSWD/nldi-db/releases/tag/artifacts-1.0.0)) and updated the dockerfiles to download from that location.