### PR TITLE
Add missing crawler_source column

### DIFF
--- a/liquibase/changeLogs/nldi/nldi_data/tables.sql
+++ b/liquibase/changeLogs/nldi/nldi_data/tables.sql
@@ -14,6 +14,7 @@ create table nldi_data.crawler_source
 ,feature_reach					character varying(500)
 ,feature_measure				character varying(500)
 ,ingest_type					character varying(5)
+,feature_type					character varying(100)
 ,constraint crawler_source_pk
   primary key (crawler_source_id)
 );


### PR DESCRIPTION
While building a test database from scratch, the liquibase failed because the crawler_source table was missing a column and it was unable to copy in the source tsv. This wasn't noticed in deployments because the databases likely had the column added manually and this liquibase step was already marked as complete. The build and test succeeded with this change.