### PR TITLE
add demonstration geoconnex features

### DIFF
--- a/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
+++ b/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
@@ -9,4 +9,4 @@ crawler_source_id	source_name	source_suffix	source_uri	feature_id	feature_name	f
 10	Vigil Network Data	vigil	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=vigil.geojson	SBID	Site Name	SBURL	nhdpv2_REACHCODE	nhdpv2_REACH_measure	reach	hydrolocation
 11	NWIS Groundwater Sites	nwisgw	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=nwis_wells.geojson	provider_id	name	subjectOf	NULL	NULL	point	point
 12	New Mexico Water Data Initative Sites	nmwdi-st	https://locations.newmexicowaterdata.org/collections/Things/items?f=json&limit=100000	id	name	geoconnex	NULL	NULL	point	point
-12	New Mexico Water Data Initative Sites	nmwdi-st	https://locations.newmexicowaterdata.org/collections/Things/items?f=json&limit=100000	id	name	geoconnex	NULL	NULL	point	point
+13	geoconnex contribution demo sites	geoconnex-demo	https://geoconnex-demo-pages.internetofwater.dev/collections/demo-gpkg/items?f=json&limit=10000	id	GNIX_NAME	uri	NHDPv2ReachCode	NHDPv2Measure	reach	hydrolocation

--- a/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
+++ b/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
@@ -9,4 +9,4 @@
 10	Vigil Network Data	vigil	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=vigil.geojson	SBID	Site Name	SBURL	nhdpv2_REACHCODE	nhdpv2_REACH_measure	reach	hydrolocation
 11	NWIS Groundwater Sites	nwisgw	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=nwis_wells.geojson	provider_id	name	subjectOf	NULL	NULL	point	point
 12	New Mexico Water Data Initative Sites	nmwdi-st	https://locations.newmexicowaterdata.org/collections/Things/items?f=json&limit=100000	id	name	geoconnex	NULL	NULL	point	point
-13  geoconnex.us demonstration features   geoconnex_demo  https://geoconnex-demo-pages.internetofwater.dev/collections/demo-gpkg/items?f=json&limit=10000 id  GNIS_NAME uri NHDPv2ReachCode NHDPv2Measure reach hydrolocation    
+13  geoconnex.us demonstration features   geoconnex_demo  https://geoconnex-demo-pages.internetofwater.dev/collections/demo-gpkg/items?f=json&limit=10000 id  GNIS_NAME uri NHDPv2ReachCode NHDPv2Measure reach hydrolocation

--- a/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
+++ b/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
@@ -9,3 +9,4 @@ crawler_source_id	source_name	source_suffix	source_uri	feature_id	feature_name	f
 10	Vigil Network Data	vigil	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=vigil.geojson	SBID	Site Name	SBURL	nhdpv2_REACHCODE	nhdpv2_REACH_measure	reach	hydrolocation
 11	NWIS Groundwater Sites	nwisgw	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=nwis_wells.geojson	provider_id	name	subjectOf	NULL	NULL	point	point
 12	New Mexico Water Data Initative Sites	nmwdi-st	https://locations.newmexicowaterdata.org/collections/Things/items?f=json&limit=100000	id	name	geoconnex	NULL	NULL	point	point
+12	New Mexico Water Data Initative Sites	nmwdi-st	https://locations.newmexicowaterdata.org/collections/Things/items?f=json&limit=100000	id	name	geoconnex	NULL	NULL	point	point

--- a/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
+++ b/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
@@ -9,4 +9,4 @@
 10	Vigil Network Data	vigil	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=vigil.geojson	SBID	Site Name	SBURL	nhdpv2_REACHCODE	nhdpv2_REACH_measure	reach	hydrolocation
 11	NWIS Groundwater Sites	nwisgw	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=nwis_wells.geojson	provider_id	name	subjectOf	NULL	NULL	point	point
 12	New Mexico Water Data Initative Sites	nmwdi-st	https://locations.newmexicowaterdata.org/collections/Things/items?f=json&limit=100000	id	name	geoconnex	NULL	NULL	point	point
-13  geoconnex.us demonstration features geoconnex_demo  https://geoconnex-demo-pages.internetofwater.dev/collections/demo-gpkg/items?f=json&limit=10000 id  GNIS_NAME uri NHDPv2ReachCode NHDPv2Measure reach hydrolocation    
+13  geoconnex.us demonstration features   geoconnex_demo  https://geoconnex-demo-pages.internetofwater.dev/collections/demo-gpkg/items?f=json&limit=10000 id  GNIS_NAME uri NHDPv2ReachCode NHDPv2Measure reach hydrolocation    

--- a/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
+++ b/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
@@ -9,4 +9,4 @@
 10 Vigil Network Data	vigil	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=vigil.geojson	SBID	Site Name	SBURL	nhdpv2_REACHCODE	nhdpv2_REACH_measure	reach	hydrolocation
 11 NWIS Groundwater Sites	nwisgw	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=nwis_wells.geojson	provider_id	name	subjectOf	NULL	NULL	point	point
 12 New Mexico Water Data Initative Sites	nmwdi-st	https://locations.newmexicowaterdata.org/collections/Things/items?f=json&limit=100000	id	name	geoconnex	NULL	NULL	point	point
-13  geoconnex.us demonstration features geoconnex_demo  https://geoconnex-demo-pages.internetofwater.dev/collections/demo-gpkg/items?f=json&limit=10000 id  GNIS_NAME uri NHDPv2ReachCode NHDPv2Measure reach hydrolocation    
+13  geoconnex.us demonstration features geoconnex_demo  https://geoconnex-demo-pages.internetofwater.dev/collections/demo-gpkg/items?f=json&limit=10000 id  GNIS_NAME uri NHDPv2ReachCode NHDPv2Measure reach hydrolocation

--- a/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
+++ b/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
@@ -9,3 +9,4 @@
 10	Vigil Network Data	vigil	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=vigil.geojson	SBID	Site Name	SBURL	nhdpv2_REACHCODE	nhdpv2_REACH_measure	reach	hydrolocation
 11	NWIS Groundwater Sites	nwisgw	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=nwis_wells.geojson	provider_id	name	subjectOf	NULL	NULL	point	point
 12	New Mexico Water Data Initative Sites	nmwdi-st	https://locations.newmexicowaterdata.org/collections/Things/items?f=json&limit=100000	id	name	geoconnex	NULL	NULL	point	point
+13  geoconnex.us demonstration features geoconnex_demo  https://geoconnex-demo-pages.internetofwater.dev/collections/demo-gpkg/items?f=json&limit=10000 id  GNIS_NAME uri NHDPv2ReachCode NHDPv2Measure reach hydrolocation    

--- a/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
+++ b/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
@@ -1,4 +1,4 @@
-﻿crawler_source_id	source_name	source_suffix	source_uri	feature_id	feature_name	feature_uri	feature_reach	feature_measure	ingest_type	feature_type
+crawler_source_id	source_name	source_suffix	source_uri	feature_id	feature_name	feature_uri	feature_reach	feature_measure	ingest_type	feature_type
 2	HUC12 Pour Points	huc12pp	https://www.sciencebase.gov/catalogMaps/mapping/ows/57336b02e4b0dae0d5dd619a?service=WFS&version=1.0.0&request=GetFeature&srsName=EPSG:4326&typeName=sb:fpp&outputFormat=json	HUC_12	HUC_12	HUC_12	NULL	NULL	point	hydrolocation
 1	Water Quality Portal	WQP	https://www.waterqualitydata.us/data/Station/search?mimeType=geojson&minactivities=1&counts=no	MonitoringLocationIdentifier	MonitoringLocationName	siteUrl	NULL	NULL	point	varies
 5	NWIS Surface Water Sites	nwissite	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=usgs_nldi_gages.geojson	provider_id	name	subjectOf	nhdpv2_REACHCODE	nhdpv2_REACH_measure	reach	hydrolocation
@@ -6,7 +6,6 @@
 7	geoconnex.us reference gages	ref_gage	https://www.hydroshare.org/resource/4a22e88e689949afa1cf71ae009eaf1b/data/contents/nldi_gages.geojson	id	name	subjectOf	nhdpv2_REACHCODE	nhdpv2_REACH_measure	reach	hydrolocation
 8	Streamgage catalog for CA SB19	ca_gages	https://sb19.linked-data.internetofwater.dev/collections/ca_gages/items?f=json&limit=10000	site_id	sitename	uri	rchcd_medres	reach_measure	reach	hydrolocation
 9	USGS Geospatial Fabric V1.1 Points of Interest	gfv11_pois	https://www.sciencebase.gov/catalogMaps/mapping/ows/609c8a63d34ea221ce3acfd3?service=WFS&version=1.0.0&request=GetFeature&srsName=EPSG:4326&typeName=sb::gfv11&outputFormat=json	prvdr_d	name	uri	n2_REACHC	n2_REACH_	reach	hydrolocation
-10 Vigil Network Data	vigil	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=vigil.geojson  SBID	Site Name	SBURL	nhdpv2_REACHCODE	nhdpv2_REACH_measure	reach	hydrolocation
-11 NWIS Groundwater Sites	nwisgw	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=nwis_wells.geojson	provider_id	name	subjectOf	NULL	NULL	point	point
-12 New Mexico Water Data Initative Sites	nmwdi-st	https://locations.newmexicowaterdata.org/collections/Things/items?f=json&limit=100000	id	name	geoconnex	NULL	NULL	point	point
-13  geoconnex.us demonstration features geoconnex_demo  https://geoconnex-demo-pages.internetofwater.dev/collections/demo-gpkg/items?f=json&limit=10000 id  GNIS_NAME uri NHDPv2ReachCode NHDPv2Measure reach hydrolocation
+10	Vigil Network Data	vigil	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=vigil.geojson	SBID	Site Name	SBURL	nhdpv2_REACHCODE	nhdpv2_REACH_measure	reach	hydrolocation
+11	NWIS Groundwater Sites	nwisgw	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=nwis_wells.geojson	provider_id	name	subjectOf	NULL	NULL	point	point
+12	New Mexico Water Data Initative Sites	nmwdi-st	https://locations.newmexicowaterdata.org/collections/Things/items?f=json&limit=100000	id	name	geoconnex	NULL	NULL	point	point

--- a/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
+++ b/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
@@ -9,4 +9,4 @@
 10 Vigil Network Data	vigil	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=vigil.geojson	SBID	Site Name	SBURL	nhdpv2_REACHCODE	nhdpv2_REACH_measure	reach	hydrolocation
 11 NWIS Groundwater Sites	nwisgw	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=nwis_wells.geojson	provider_id	name	subjectOf	NULL	NULL	point	point
 12 New Mexico Water Data Initative Sites	nmwdi-st	https://locations.newmexicowaterdata.org/collections/Things/items?f=json&limit=100000	id	name	geoconnex	NULL	NULL	point	point
-13 geoconnex.us demonstration features   geoconnex_demo  https://geoconnex-demo-pages.internetofwater.dev/collections/demo-gpkg/items?f=json&limit=10000 id  GNIS_NAME uri NHDPv2ReachCode NHDPv2Measure reach hydrolocation
+13  geoconnex.us demonstration features geoconnex_demo  https://geoconnex-demo-pages.internetofwater.dev/collections/demo-gpkg/items?f=json&limit=10000 id  GNIS_NAME uri NHDPv2ReachCode NHDPv2Measure reach hydrolocation    

--- a/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
+++ b/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
@@ -6,7 +6,7 @@
 7	geoconnex.us reference gages	ref_gage	https://www.hydroshare.org/resource/4a22e88e689949afa1cf71ae009eaf1b/data/contents/nldi_gages.geojson	id	name	subjectOf	nhdpv2_REACHCODE	nhdpv2_REACH_measure	reach	hydrolocation
 8	Streamgage catalog for CA SB19	ca_gages	https://sb19.linked-data.internetofwater.dev/collections/ca_gages/items?f=json&limit=10000	site_id	sitename	uri	rchcd_medres	reach_measure	reach	hydrolocation
 9	USGS Geospatial Fabric V1.1 Points of Interest	gfv11_pois	https://www.sciencebase.gov/catalogMaps/mapping/ows/609c8a63d34ea221ce3acfd3?service=WFS&version=1.0.0&request=GetFeature&srsName=EPSG:4326&typeName=sb::gfv11&outputFormat=json	prvdr_d	name	uri	n2_REACHC	n2_REACH_	reach	hydrolocation
-10 Vigil Network Data	vigil	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=vigil.geojson	SBID	Site Name	SBURL	nhdpv2_REACHCODE	nhdpv2_REACH_measure	reach	hydrolocation
+10 Vigil Network Data	vigil	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=vigil.geojson  SBID	Site Name	SBURL	nhdpv2_REACHCODE	nhdpv2_REACH_measure	reach	hydrolocation
 11 NWIS Groundwater Sites	nwisgw	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=nwis_wells.geojson	provider_id	name	subjectOf	NULL	NULL	point	point
 12 New Mexico Water Data Initative Sites	nmwdi-st	https://locations.newmexicowaterdata.org/collections/Things/items?f=json&limit=100000	id	name	geoconnex	NULL	NULL	point	point
 13  geoconnex.us demonstration features geoconnex_demo  https://geoconnex-demo-pages.internetofwater.dev/collections/demo-gpkg/items?f=json&limit=10000 id  GNIS_NAME uri NHDPv2ReachCode NHDPv2Measure reach hydrolocation

--- a/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
+++ b/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
@@ -6,7 +6,7 @@
 7	geoconnex.us reference gages	ref_gage	https://www.hydroshare.org/resource/4a22e88e689949afa1cf71ae009eaf1b/data/contents/nldi_gages.geojson	id	name	subjectOf	nhdpv2_REACHCODE	nhdpv2_REACH_measure	reach	hydrolocation
 8	Streamgage catalog for CA SB19	ca_gages	https://sb19.linked-data.internetofwater.dev/collections/ca_gages/items?f=json&limit=10000	site_id	sitename	uri	rchcd_medres	reach_measure	reach	hydrolocation
 9	USGS Geospatial Fabric V1.1 Points of Interest	gfv11_pois	https://www.sciencebase.gov/catalogMaps/mapping/ows/609c8a63d34ea221ce3acfd3?service=WFS&version=1.0.0&request=GetFeature&srsName=EPSG:4326&typeName=sb::gfv11&outputFormat=json	prvdr_d	name	uri	n2_REACHC	n2_REACH_	reach	hydrolocation
-10	Vigil Network Data	vigil	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=vigil.geojson	SBID	Site Name	SBURL	nhdpv2_REACHCODE	nhdpv2_REACH_measure	reach	hydrolocation
-11	NWIS Groundwater Sites	nwisgw	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=nwis_wells.geojson	provider_id	name	subjectOf	NULL	NULL	point	point
-12	New Mexico Water Data Initative Sites	nmwdi-st	https://locations.newmexicowaterdata.org/collections/Things/items?f=json&limit=100000	id	name	geoconnex	NULL	NULL	point	point
-13  geoconnex.us demonstration features   geoconnex_demo  https://geoconnex-demo-pages.internetofwater.dev/collections/demo-gpkg/items?f=json&limit=10000 id  GNIS_NAME uri NHDPv2ReachCode NHDPv2Measure reach hydrolocation
+10 Vigil Network Data	vigil	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=vigil.geojson	SBID	Site Name	SBURL	nhdpv2_REACHCODE	nhdpv2_REACH_measure	reach	hydrolocation
+11 NWIS Groundwater Sites	nwisgw	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=nwis_wells.geojson	provider_id	name	subjectOf	NULL	NULL	point	point
+12 New Mexico Water Data Initative Sites	nmwdi-st	https://locations.newmexicowaterdata.org/collections/Things/items?f=json&limit=100000	id	name	geoconnex	NULL	NULL	point	point
+13 geoconnex.us demonstration features   geoconnex_demo  https://geoconnex-demo-pages.internetofwater.dev/collections/demo-gpkg/items?f=json&limit=10000 id  GNIS_NAME uri NHDPv2ReachCode NHDPv2Measure reach hydrolocation

--- a/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
+++ b/liquibase/changeLogs/nldi/nldi_data/update_crawler_source/crawler_source.tsv
@@ -9,4 +9,4 @@ crawler_source_id	source_name	source_suffix	source_uri	feature_id	feature_name	f
 10	Vigil Network Data	vigil	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=vigil.geojson	SBID	Site Name	SBURL	nhdpv2_REACHCODE	nhdpv2_REACH_measure	reach	hydrolocation
 11	NWIS Groundwater Sites	nwisgw	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=nwis_wells.geojson	provider_id	name	subjectOf	NULL	NULL	point	point
 12	New Mexico Water Data Initative Sites	nmwdi-st	https://locations.newmexicowaterdata.org/collections/Things/items?f=json&limit=100000	id	name	geoconnex	NULL	NULL	point	point
-13	geoconnex contribution demo sites	geoconnex-demo	https://geoconnex-demo-pages.internetofwater.dev/collections/demo-gpkg/items?f=json&limit=10000	id	GNIX_NAME	uri	NHDPv2ReachCode	NHDPv2Measure	reach	hydrolocation
+13	geoconnex contribution demo sites	geoconnex-demo	https://geoconnex-demo-pages.internetofwater.dev/collections/demo-gpkg/items?f=json&limit=10000	id	GNIS_NAME	uri	NHDPv2ReachCode	NHDPv2Measure	reach	hydrolocation


### PR DESCRIPTION
This PR adds a set of 2023 points with hydrologic addresses. This pull request and dataset is designed to be a used as an example as part of a tutorial for water data providers to participate in the https://geoconnex.us system and the NLDI in concert. It will be referenced in guidance materials that walk data users through:

1. Use HydroAdd to add hydrologic addresses to spatial point datasets
2. Publish persistently identified feature-level web resources as HTML pages that include script headers with JSON-LD including structured references to hydrologic addresses according to the HY_Features model
3. Register these data with the NLDI
4. Use the NLDI to discover data. 